### PR TITLE
Creación de entidad Proveedores y relación con Productos

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { HospitalBedsModule } from './hospital-beds/hospital-beds.module';
 import { PosModule } from './pos/pos.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
+import { SuppliersModule } from './suppliers/suppliers.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { ConfigModule } from '@nestjs/config';
     PartnersModule,
     HospitalBedsModule,
     PosModule,
+    SuppliersModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/inventory/dto/create-inventory.dto.ts
+++ b/src/inventory/dto/create-inventory.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsInt, IsOptional, IsString } from 'class-validator';
+import { IsInt, IsOptional, IsString, Min } from 'class-validator';
 
 export class InventoryMovementDto {
   @ApiProperty({ description: 'ID del movimiento de stock' })
@@ -43,6 +43,7 @@ export class CreateInventoryMovementDto {
     example: 5,
   })
   @IsInt()
+  @Min(1, { message: 'La cantidad debe ser mayor que 0' })
   quantity: number;
 
   // @ApiProperty({

--- a/src/inventory/dto/purchase.dto.ts
+++ b/src/inventory/dto/purchase.dto.ts
@@ -1,16 +1,29 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsInt,
+  IsPositive,
+  Min,
+  ValidateNested,
+} from 'class-validator';
 
 export class PurchaseProductDto {
   @ApiProperty({
     description: 'ID del producto que se va a comprar',
     example: 1,
   })
+  @IsInt({ message: 'El productId debe ser un número entero' })
+  @IsPositive({ message: 'El productId debe ser mayor a 0' })
   productId: number;
 
   @ApiProperty({
     description: 'Cantidad de producto a comprar',
     example: 10,
   })
+  @IsInt({ message: 'La cantidad debe ser un número entero' })
+  @IsPositive({ message: 'La cantidad debe ser mayor que 0' })
+  @Min(1, { message: 'La cantidad debe ser mayor que 0' })
   quantity: number;
 }
 
@@ -25,6 +38,9 @@ export class MovementDto {
     description: 'Lista de productos a comprar',
     type: [PurchaseProductDto],
   })
+  @IsArray({ message: 'Products debe ser un arreglo' })
+  @ValidateNested({ each: true })
+  @Type(() => PurchaseProductDto)
   products: PurchaseProductDto[];
 }
 

--- a/src/inventory/entities/products.entity.ts
+++ b/src/inventory/entities/products.entity.ts
@@ -11,6 +11,7 @@ import { Inventory } from './inventory.entity';
 import { MenuProduct } from './menu_product.entity';
 import { Expose } from 'class-transformer';
 import { Category } from './product_category.entity';
+import { SupplierProduct } from 'src/suppliers/entities/supplier-product.entity';
 @Entity()
 export class Product {
   @PrimaryGeneratedColumn()
@@ -63,4 +64,7 @@ export class Product {
 
   @ManyToOne(() => Category, (category) => category.products, { eager: true })
   category: Category;
+
+  @OneToMany(() => SupplierProduct, (sp) => sp.supplier)
+  supplierProducts: SupplierProduct[];
 }

--- a/src/inventory/services/products.service.ts
+++ b/src/inventory/services/products.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   forwardRef,
   Inject,
   Injectable,
@@ -10,11 +11,7 @@ import { Repository } from 'typeorm';
 import { Product } from '../entities/products.entity';
 import { CreateProductDto } from 'src/inventory/dto/create-product.dto';
 import { UpdateProductDto } from '../dto/update-product.dto';
-import {
-  AddSaleDto,
-  MovementDto,
-  PurchaseProductDto,
-} from '../dto/purchase.dto';
+import { MovementDto, PurchaseProductDto } from '../dto/purchase.dto';
 import { InventoryReasons } from 'src/types/movementReason.enum';
 import { InventoryService } from '../inventory.service';
 import { CreateInventoryMovementDto } from '../dto/create-inventory.dto';
@@ -171,6 +168,11 @@ export class ProductService {
     // Validate and process the purchase DTO
     for (const product of movementDto.products) {
       const { productId, quantity } = product;
+
+      if (!quantity || quantity <= 0) {
+        throw new BadRequestException('La cantidad debe ser mayor que 0');
+      }
+
       await this.addStockProduct({ productId, quantity });
       const buildMovementDto: CreateInventoryMovementDto = {
         productId,

--- a/src/suppliers/dto/create-supplier-product.dto.ts
+++ b/src/suppliers/dto/create-supplier-product.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsNumber, IsPositive } from 'class-validator';
+
+export class CreateSupplierProductDto {
+  @ApiProperty({ example: 21, description: 'productId' })
+  @IsInt()
+  productId: number;
+
+  @ApiProperty({
+    example: 150.5,
+    description: 'Precio de costo que ofrece el proveedor',
+  })
+  @IsNumber()
+  @IsPositive()
+  costPrice: number;
+}

--- a/src/suppliers/dto/create-supplier.dto.ts
+++ b/src/suppliers/dto/create-supplier.dto.ts
@@ -1,0 +1,48 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Length,
+} from 'class-validator';
+
+export class CreateSupplierDto {
+  @ApiProperty({
+    description: 'Nombre del proveedor',
+    example: 'Proveedor de Carnes S.A.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Length(2, 100)
+  name: string;
+
+  @ApiProperty({
+    description: 'Email del proveedor',
+    example: 'contacto@carnes.com',
+    required: false,
+  })
+  @IsEmail()
+  @IsOptional()
+  email?: string;
+
+  @ApiProperty({
+    description: 'Teléfono del proveedor',
+    example: '01112345678',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  @Length(6, 20)
+  phone?: string;
+
+  @ApiProperty({
+    description: 'Dirección del proveedor',
+    example: 'Calle Falsa 123',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  @Length(5, 200)
+  address?: string;
+}

--- a/src/suppliers/dto/create-supplier.dto.ts
+++ b/src/suppliers/dto/create-supplier.dto.ts
@@ -1,11 +1,25 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
 import {
+  IsArray,
   IsEmail,
   IsNotEmpty,
+  IsNumber,
   IsOptional,
   IsString,
   Length,
+  ValidateNested,
 } from 'class-validator';
+
+class CreateSupplierProductInlineDto {
+  @ApiProperty()
+  @IsNumber()
+  productId: number;
+
+  @ApiProperty()
+  @IsNumber()
+  costPrice: number;
+}
 
 export class CreateSupplierDto {
   @ApiProperty({
@@ -45,4 +59,11 @@ export class CreateSupplierDto {
   @IsOptional()
   @Length(5, 200)
   address?: string;
+
+  @ApiProperty({ type: [CreateSupplierProductInlineDto], required: false })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateSupplierProductInlineDto)
+  products?: CreateSupplierProductInlineDto[];
 }

--- a/src/suppliers/dto/update-supplier-product.dto.ts
+++ b/src/suppliers/dto/update-supplier-product.dto.ts
@@ -1,0 +1,6 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSupplierProductDto } from './create-supplier-product.dto';
+
+export class UpdateSupplierProductDto extends PartialType(
+  CreateSupplierProductDto,
+) {}

--- a/src/suppliers/dto/update-supplier.dto.ts
+++ b/src/suppliers/dto/update-supplier.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateSupplierDto } from './create-supplier.dto';
+
+export class UpdateSupplierDto extends PartialType(CreateSupplierDto) {}

--- a/src/suppliers/dto/update-supplier.dto.ts
+++ b/src/suppliers/dto/update-supplier.dto.ts
@@ -1,4 +1,27 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateSupplierDto } from './create-supplier.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
-export class UpdateSupplierDto extends PartialType(CreateSupplierDto) {}
+export class UpdateSupplierDto {
+  @ApiProperty({
+    example: 'Proveedor ACME',
+    description: 'Nombre del proveedor',
+  })
+  name: string;
+
+  @ApiProperty({
+    example: 'acme@email.com',
+    description: 'Correo electrónico del proveedor',
+  })
+  email: string;
+
+  @ApiProperty({
+    example: '123456789',
+    description: 'Teléfono de contacto',
+  })
+  phone: string;
+
+  @ApiProperty({
+    example: 'calle falsa 123',
+    description: 'Dirección  del proveedor',
+  })
+  address: string;
+}

--- a/src/suppliers/entities/supplier-product.entity.ts
+++ b/src/suppliers/entities/supplier-product.entity.ts
@@ -1,0 +1,46 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Supplier } from './supplier.entity';
+import { Product } from 'src/inventory/entities/products.entity';
+// Transformer para decimal -> number (TypeORM guarda DECIMAL como string)
+const decimalTransformer = {
+  to: (value: number) => value,
+  from: (value: string) => (value === null ? null : parseFloat(value)),
+};
+
+@Entity('supplier_products')
+@Unique(['supplier', 'product'])
+export class SupplierProduct {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Supplier, (s) => s.supplierProducts, { onDelete: 'CASCADE' })
+  supplier: Supplier;
+
+  @ManyToOne(() => Product, (p) => p.supplierProducts, { onDelete: 'CASCADE' })
+  product: Product;
+
+  // Precio de costo que ofrece este proveedor para este producto
+  @Column('decimal', {
+    precision: 10,
+    scale: 2,
+    transformer: decimalTransformer,
+  })
+  costPrice: number;
+
+  @Column({ default: true })
+  active: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/suppliers/entities/supplier.entity.ts
+++ b/src/suppliers/entities/supplier.entity.ts
@@ -1,0 +1,34 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('suppliers')
+export class Supplier {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 100 })
+  name: string;
+
+  @Column({ nullable: true, length: 150 })
+  email: string;
+
+  @Column({ nullable: true, length: 20 })
+  phone: string;
+
+  @Column({ nullable: true, length: 200 })
+  address: string;
+
+  @Column({ default: true })
+  active: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/suppliers/entities/supplier.entity.ts
+++ b/src/suppliers/entities/supplier.entity.ts
@@ -2,9 +2,11 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  OneToMany,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+import { SupplierProduct } from './supplier-product.entity';
 
 @Entity('suppliers')
 export class Supplier {
@@ -31,4 +33,7 @@ export class Supplier {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  @OneToMany(() => SupplierProduct, (sp) => sp.supplier)
+  supplierProducts: SupplierProduct[];
 }

--- a/src/suppliers/suppliers-product.controller.ts
+++ b/src/suppliers/suppliers-product.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Patch,
+  Delete,
+  Param,
+  Body,
+  ParseIntPipe,
+} from '@nestjs/common';
+import { CreateSupplierProductDto } from './dto/create-supplier-product.dto';
+import { UpdateSupplierProductDto } from './dto/update-supplier-product.dto';
+import { SupplierProductsService } from './suppliers-products.service';
+import { ApiOperation } from '@nestjs/swagger';
+
+@Controller('supplier-products')
+export class SupplierProductsController {
+  constructor(private readonly spService: SupplierProductsService) {}
+
+  // Crear relación proveedor-producto
+  @Post(':supplierId')
+  @ApiOperation({ summary: 'Asociar un producto a un proveedor' })
+  addProductToSupplier(
+    @Param('supplierId', ParseIntPipe) supplierId: number,
+    @Body() dto: CreateSupplierProductDto,
+  ) {
+    return this.spService.addProductToSupplier(supplierId, dto);
+  }
+
+  // Listar todos los productos de un proveedor
+  @Get('by-supplier/:supplierId')
+  @ApiOperation({ summary: 'Listar productos de un proveedor' })
+  listBySupplier(@Param('supplierId', ParseIntPipe) supplierId: number) {
+    return this.spService.listBySupplier(supplierId);
+  }
+
+  // Listar todos los proveedores que ofrecen un producto
+  @Get('by-product/:productId')
+  @ApiOperation({ summary: 'Listar proveedores de un producto' })
+  listSuppliersByProduct(@Param('productId', ParseIntPipe) productId: number) {
+    return this.spService.listSuppliersByProduct(productId);
+  }
+
+  // Actualizar precio de costo
+  @Patch(':supplierId/:productId')
+  @ApiOperation({ summary: 'Actualizar precio de costo' })
+  updatePrice(
+    @Param('supplierId', ParseIntPipe) supplierId: number,
+    @Param('productId', ParseIntPipe) productId: number,
+    @Body() dto: UpdateSupplierProductDto,
+  ) {
+    return this.spService.updatePrice(supplierId, productId, dto);
+  }
+
+  // Eliminar (desactivar) un producto de un proveedor
+  @Delete(':supplierId/:productId')
+  @ApiOperation({ summary: 'Desactivar producto de un proveedor' })
+  removeProduct(
+    @Param('supplierId', ParseIntPipe) supplierId: number,
+    @Param('productId', ParseIntPipe) productId: number,
+  ) {
+    return this.spService.removeProduct(supplierId, productId);
+  }
+}

--- a/src/suppliers/suppliers-products.service.ts
+++ b/src/suppliers/suppliers-products.service.ts
@@ -1,0 +1,127 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Supplier } from './entities/supplier.entity';
+import { SupplierProduct } from './entities/supplier-product.entity';
+import { CreateSupplierProductDto } from './dto/create-supplier-product.dto';
+import { UpdateSupplierProductDto } from './dto/update-supplier-product.dto';
+import { Product } from 'src/inventory/entities/products.entity';
+
+@Injectable()
+export class SupplierProductsService {
+  constructor(
+    @InjectRepository(SupplierProduct)
+    private readonly supplierProductRepo: Repository<SupplierProduct>,
+
+    @InjectRepository(Supplier)
+    private readonly supplierRepo: Repository<Supplier>,
+
+    @InjectRepository(Product)
+    private readonly productRepo: Repository<Product>,
+  ) {}
+
+  /**
+   * Asocia un producto a un proveedor con un precio de costo
+   */
+  async addProductToSupplier(
+    supplierId: number,
+    dto: CreateSupplierProductDto,
+  ): Promise<SupplierProduct> {
+    const supplier = await this.supplierRepo.findOne({
+      where: { id: supplierId },
+    });
+    if (!supplier)
+      throw new NotFoundException(`Supplier ${supplierId} not found`);
+
+    const product = await this.productRepo.findOne({
+      where: { id: dto.productId },
+    });
+    if (!product)
+      throw new NotFoundException(`Product ${dto.productId} not found`);
+
+    // Verificar si ya existe la relación
+    const existing = await this.supplierProductRepo.findOne({
+      where: { supplier: { id: supplierId }, product: { id: dto.productId } },
+      relations: ['supplier', 'product'],
+    });
+
+    if (existing) {
+      if (existing.active) {
+        throw new BadRequestException(
+          `Supplier ${supplierId} already offers Product ${dto.productId}`,
+        );
+      }
+      // Reactivar y actualizar precio
+      existing.costPrice = dto.costPrice;
+      existing.active = true;
+      return this.supplierProductRepo.save(existing);
+    }
+
+    const supplierProduct = this.supplierProductRepo.create({
+      supplier,
+      product,
+      costPrice: dto.costPrice,
+    });
+    return this.supplierProductRepo.save(supplierProduct);
+  }
+
+  /**
+   * Lista todos los productos ofrecidos por un proveedor
+   */
+  async listBySupplier(supplierId: number): Promise<SupplierProduct[]> {
+    return this.supplierProductRepo.find({
+      where: { supplier: { id: supplierId }, active: true },
+      relations: ['product'],
+    });
+  }
+
+  /**
+   * Lista todos los proveedores que ofrecen un producto
+   */
+  async listSuppliersByProduct(productId: number): Promise<SupplierProduct[]> {
+    return this.supplierProductRepo.find({
+      where: { product: { id: productId }, active: true },
+      relations: ['supplier'],
+    });
+  }
+
+  /**
+   * Actualiza el precio de costo de un producto ofrecido por un proveedor
+   */
+  async updatePrice(
+    supplierId: number,
+    productId: number,
+    dto: UpdateSupplierProductDto,
+  ): Promise<SupplierProduct> {
+    const sp = await this.supplierProductRepo.findOne({
+      where: { supplier: { id: supplierId }, product: { id: productId } },
+      relations: ['supplier', 'product'],
+    });
+
+    if (!sp) throw new NotFoundException(`Relation not found`);
+
+    if (dto.costPrice) {
+      sp.costPrice = dto.costPrice;
+    }
+
+    return this.supplierProductRepo.save(sp);
+  }
+
+  /**
+   * Elimina (desactiva) un producto de un proveedor
+   */
+  async removeProduct(supplierId: number, productId: number): Promise<void> {
+    const sp = await this.supplierProductRepo.findOne({
+      where: { supplier: { id: supplierId }, product: { id: productId } },
+    });
+
+    if (!sp) throw new NotFoundException(`Relation not found`);
+
+    sp.active = false;
+    await this.supplierProductRepo.save(sp);
+  }
+}

--- a/src/suppliers/suppliers.controller.spec.ts
+++ b/src/suppliers/suppliers.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SuppliersController } from './suppliers.controller';
+import { SuppliersService } from './suppliers.service';
+
+describe('SuppliersController', () => {
+  let controller: SuppliersController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SuppliersController],
+      providers: [SuppliersService],
+    }).compile();
+
+    controller = module.get<SuppliersController>(SuppliersController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/suppliers/suppliers.controller.ts
+++ b/src/suppliers/suppliers.controller.ts
@@ -1,0 +1,48 @@
+// suppliers.controller.ts
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { SuppliersService } from './suppliers.service';
+import { CreateSupplierDto } from './dto/create-supplier.dto';
+import { UpdateSupplierDto } from './dto/update-supplier.dto';
+import { ApiCreatedResponse } from '@nestjs/swagger';
+
+@Controller('suppliers')
+export class SuppliersController {
+  constructor(private readonly suppliersService: SuppliersService) {}
+
+  @Post()
+  @ApiCreatedResponse({
+    description: 'Proveedor creado correctamente',
+    type: CreateSupplierDto,
+  })
+  create(@Body() dto: CreateSupplierDto) {
+    return this.suppliersService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.suppliersService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.suppliersService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateSupplierDto) {
+    return this.suppliersService.update(+id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.suppliersService.remove(+id);
+  }
+}

--- a/src/suppliers/suppliers.module.ts
+++ b/src/suppliers/suppliers.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SuppliersController } from './suppliers.controller';
+import { SuppliersService } from './suppliers.service';
+import { Supplier } from './entities/supplier.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Supplier])],
+  controllers: [SuppliersController],
+  providers: [SuppliersService],
+  exports: [SuppliersService],
+})
+export class SuppliersModule {}

--- a/src/suppliers/suppliers.module.ts
+++ b/src/suppliers/suppliers.module.ts
@@ -3,11 +3,15 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { SuppliersController } from './suppliers.controller';
 import { SuppliersService } from './suppliers.service';
 import { Supplier } from './entities/supplier.entity';
+import { SupplierProduct } from './entities/supplier-product.entity';
+import { Product } from 'src/inventory/entities/products.entity';
+import { SupplierProductsService } from './suppliers-products.service';
+import { SupplierProductsController } from './suppliers-product.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Supplier])],
-  controllers: [SuppliersController],
-  providers: [SuppliersService],
-  exports: [SuppliersService],
+  imports: [TypeOrmModule.forFeature([Supplier, SupplierProduct, Product])],
+  controllers: [SuppliersController, SupplierProductsController],
+  providers: [SuppliersService, SupplierProductsService],
+  exports: [SuppliersService, SupplierProductsService],
 })
 export class SuppliersModule {}

--- a/src/suppliers/suppliers.service.spec.ts
+++ b/src/suppliers/suppliers.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SuppliersService } from './suppliers.service';
+
+describe('SuppliersService', () => {
+  let service: SuppliersService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SuppliersService],
+    }).compile();
+
+    service = module.get<SuppliersService>(SuppliersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/suppliers/suppliers.service.ts
+++ b/src/suppliers/suppliers.service.ts
@@ -1,0 +1,42 @@
+// suppliers.service.ts
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CreateSupplierDto } from './dto/create-supplier.dto';
+import { UpdateSupplierDto } from './dto/update-supplier.dto';
+import { Supplier } from './entities/supplier.entity';
+
+@Injectable()
+export class SuppliersService {
+  constructor(
+    @InjectRepository(Supplier)
+    private readonly supplierRepo: Repository<Supplier>,
+  ) {}
+
+  async create(createSupplierDto: CreateSupplierDto): Promise<Supplier> {
+    const supplier = this.supplierRepo.create(createSupplierDto);
+    return this.supplierRepo.save(supplier);
+  }
+
+  findAll(): Promise<Supplier[]> {
+    return this.supplierRepo.find();
+  }
+
+  async findOne(id: number): Promise<Supplier> {
+    const supplier = await this.supplierRepo.findOne({ where: { id } });
+    if (!supplier) throw new NotFoundException('Supplier not found');
+    return supplier;
+  }
+
+  async update(
+    id: number,
+    updateSupplierDto: UpdateSupplierDto,
+  ): Promise<Supplier> {
+    await this.supplierRepo.update(id, updateSupplierDto);
+    return this.findOne(id);
+  }
+
+  async remove(id: number): Promise<void> {
+    await this.supplierRepo.update(id, { active: false });
+  }
+}

--- a/src/suppliers/suppliers.service.ts
+++ b/src/suppliers/suppliers.service.ts
@@ -1,5 +1,5 @@
 // suppliers.service.ts
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, Put } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateSupplierDto } from './dto/create-supplier.dto';
@@ -7,6 +7,7 @@ import { UpdateSupplierDto } from './dto/update-supplier.dto';
 import { Supplier } from './entities/supplier.entity';
 import { SupplierProduct } from './entities/supplier-product.entity';
 import { Product } from 'src/inventory/entities/products.entity';
+import { ApiBody } from '@nestjs/swagger';
 
 @Injectable()
 export class SuppliersService {
@@ -68,7 +69,7 @@ export class SuppliersService {
   async findOne(id: number): Promise<Supplier> {
     const supplier = await this.supplierRepo.findOne({
       where: { id },
-      relations: ['supplierProducts', 'supplierProducts.product'], // 👈
+      relations: ['supplierProducts', 'supplierProducts.product'],
     });
     if (!supplier) {
       throw new NotFoundException(`Supplier #${id} not found`);
@@ -76,11 +77,14 @@ export class SuppliersService {
     return supplier;
   }
 
+  @Put(':id')
+  @ApiBody({ type: UpdateSupplierDto })
   async update(
     id: number,
     updateSupplierDto: UpdateSupplierDto,
   ): Promise<Supplier> {
-    await this.supplierRepo.update(id, updateSupplierDto);
+    const { name, email, phone, address } = updateSupplierDto;
+    await this.supplierRepo.update(id, { name, email, phone, address });
     return this.findOne(id);
   }
 

--- a/src/suppliers/suppliers.service.ts
+++ b/src/suppliers/suppliers.service.ts
@@ -60,6 +60,7 @@ export class SuppliersService {
 
   async findAll(): Promise<Supplier[]> {
     return this.supplierRepo.find({
+      where: { active: true },
       relations: ['supplierProducts', 'supplierProducts.product'],
     });
   }

--- a/src/suppliers/suppliers.service.ts
+++ b/src/suppliers/suppliers.service.ts
@@ -5,26 +5,73 @@ import { Repository } from 'typeorm';
 import { CreateSupplierDto } from './dto/create-supplier.dto';
 import { UpdateSupplierDto } from './dto/update-supplier.dto';
 import { Supplier } from './entities/supplier.entity';
+import { SupplierProduct } from './entities/supplier-product.entity';
+import { Product } from 'src/inventory/entities/products.entity';
 
 @Injectable()
 export class SuppliersService {
   constructor(
     @InjectRepository(Supplier)
     private readonly supplierRepo: Repository<Supplier>,
+
+    @InjectRepository(SupplierProduct)
+    private readonly supplierProductRepo: Repository<SupplierProduct>,
+
+    @InjectRepository(Product)
+    private readonly productRepo: Repository<Product>,
   ) {}
 
   async create(createSupplierDto: CreateSupplierDto): Promise<Supplier> {
-    const supplier = this.supplierRepo.create(createSupplierDto);
-    return this.supplierRepo.save(supplier);
+    const { products, ...supplierData } = createSupplierDto;
+
+    const supplier = this.supplierRepo.create(supplierData);
+    const savedSupplier = await this.supplierRepo.save(supplier);
+
+    if (products && products.length > 0) {
+      const supplierProducts: SupplierProduct[] = [];
+      for (const p of products) {
+        const product = await this.productRepo.findOne({
+          where: { id: p.productId },
+        });
+        if (!product)
+          throw new NotFoundException(`Product ${p.productId} not found`);
+
+        supplierProducts.push(
+          this.supplierProductRepo.create({
+            supplier: savedSupplier,
+            product,
+            costPrice: p.costPrice,
+          }),
+        );
+      }
+      await this.supplierProductRepo.save(supplierProducts);
+    }
+
+    const fullSupplier = await this.supplierRepo.findOne({
+      where: { id: savedSupplier.id },
+      relations: ['supplierProducts', 'supplierProducts.product'],
+    });
+
+    if (!fullSupplier)
+      throw new NotFoundException(`Supplier not found after creation`);
+
+    return fullSupplier;
   }
 
-  findAll(): Promise<Supplier[]> {
-    return this.supplierRepo.find();
+  async findAll(): Promise<Supplier[]> {
+    return this.supplierRepo.find({
+      relations: ['supplierProducts', 'supplierProducts.product'],
+    });
   }
 
   async findOne(id: number): Promise<Supplier> {
-    const supplier = await this.supplierRepo.findOne({ where: { id } });
-    if (!supplier) throw new NotFoundException('Supplier not found');
+    const supplier = await this.supplierRepo.findOne({
+      where: { id },
+      relations: ['supplierProducts', 'supplierProducts.product'], // 👈
+    });
+    if (!supplier) {
+      throw new NotFoundException(`Supplier #${id} not found`);
+    }
     return supplier;
   }
 

--- a/src/suppliers/suppliers.service.ts
+++ b/src/suppliers/suppliers.service.ts
@@ -1,5 +1,10 @@
 // suppliers.service.ts
-import { Injectable, NotFoundException, Put } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+  Put,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateSupplierDto } from './dto/create-supplier.dto';
@@ -24,6 +29,39 @@ export class SuppliersService {
 
   async create(createSupplierDto: CreateSupplierDto): Promise<Supplier> {
     const { products, ...supplierData } = createSupplierDto;
+
+    if (supplierData.name) {
+      const existingByName = await this.supplierRepo.findOne({
+        where: { name: supplierData.name },
+      });
+      if (existingByName) {
+        throw new BadRequestException(
+          `Ya existe un proveedor con el nombre: ${supplierData.name}`,
+        );
+      }
+    }
+
+    if (supplierData.email) {
+      const existingByEmail = await this.supplierRepo.findOne({
+        where: { email: supplierData.email },
+      });
+      if (existingByEmail) {
+        throw new BadRequestException(
+          `Ya existe un proveedor con el email: ${supplierData.email}`,
+        );
+      }
+    }
+
+    if (supplierData.phone) {
+      const existingByPhone = await this.supplierRepo.findOne({
+        where: { phone: supplierData.phone },
+      });
+      if (existingByPhone) {
+        throw new BadRequestException(
+          `Ya existe un proveedor con el teléfono: ${supplierData.phone}`,
+        );
+      }
+    }
 
     const supplier = this.supplierRepo.create(supplierData);
     const savedSupplier = await this.supplierRepo.save(supplier);


### PR DESCRIPTION
Este PR implementa la relación many-to-many entre Suppliers y Products mediante una tabla intermedia SupplierProducts.
Ahora cada proveedor puede ofrecer múltiples productos con un costPrice específico, y cada producto puede estar asociado a varios proveedores.

**Nueva entidad SupplierProduct** (tabla intermedia)

- Representa la relación Supplier ↔ Product.
- Contiene atributos propios de la relación:
costPrice
active
timestamps (createdAt, updatedAt).


**Nuevo módulo supplier-products**

Service con métodos para:

- Agregar un producto a un proveedor.
- Listar productos por proveedor.
- Listar proveedores por producto.
- Actualizar el precio de costo.
- Desactivar un producto de un proveedor.
- Controller con endpoints expuestos en Swagger para probar estas operaciones.

**Modificaciones en suppliers**

Al crear un supplier, ahora se pueden incluir productos asociados en el mismo request (products en el DTO).

Se ajustaron los métodos findAll y findOne para que devuelvan los productos relacionados en la respuesta.


Ejemplo de flujo :
Crear Supplier (POST /suppliers)
   Body:
   {
     "name": "Empresa de Bebidas",
     "email": "contacto@bebidas.com",
     "phone": "01112345678",
     "address": "Calle Falsa 123",
     "products": [
       { "productId": 1, "costPrice": 1500 },
       { "productId": 2, "costPrice": 800 }
     ]
   }

   ➝ Se crea el registro en "suppliers"
   ➝ Se generan las relaciones en "supplier_products"