### PR TITLE
Fix: Permitir nombres de camas duplicados en habitaciones diferentes

### DIFF
--- a/src/beds/beds.service.ts
+++ b/src/beds/beds.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { ConflictException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { FindOptionsWhere, Not, Repository } from 'typeorm';
 import { Bed } from './entities/bed.entity';
 import { CreateBedDto } from './dto/create-bed.dto';
 import { UpdateBedDto } from './dto/update-bed.dto';
@@ -12,7 +12,18 @@ export class BedsService {
     private readonly bedRepository: Repository<Bed>,
   ) {}
 
-  create(createBedDto: CreateBedDto) {
+  // create(createBedDto: CreateBedDto) {
+  //   const bed = this.bedRepository.create(createBedDto);
+  //   return this.bedRepository.save(bed);
+  // }
+
+  async create(createBedDto: CreateBedDto) {
+    // Validar que no exista otra cama con el mismo nombre en la misma habitación
+    await this.validateUniqueBedNameInRoom(
+      createBedDto.name,
+      createBedDto.roomId,
+    );
+
     const bed = this.bedRepository.create(createBedDto);
     return this.bedRepository.save(bed);
   }
@@ -33,5 +44,32 @@ export class BedsService {
   async remove(id: number) {
     await this.bedRepository.delete(id);
     return { deleted: true };
+  }
+
+  private async validateUniqueBedNameInRoom(
+    name: string,
+    roomId: number,
+    excludeBedId?: number,
+  ) {
+    const whereCondition: FindOptionsWhere<Bed> = {
+      name,
+      room: { id: roomId },
+    };
+
+    // Si es una actualización, excluir la cama actual
+    if (excludeBedId) {
+      whereCondition.id = Not(excludeBedId);
+    }
+
+    const existingBed = await this.bedRepository.findOne({
+      where: whereCondition,
+      relations: ['room'],
+    });
+
+    if (existingBed) {
+      throw new ConflictException(
+        `Ya existe una cama con el nombre "${name}" en esta habitación`,
+      );
+    }
   }
 }

--- a/src/beds/entities/bed.entity.ts
+++ b/src/beds/entities/bed.entity.ts
@@ -4,18 +4,20 @@ import {
   Column,
   ManyToOne,
   OneToMany,
+  Unique,
 } from 'typeorm';
 import { Room } from 'src/rooms/entities/room.entity';
 import { BedMenu } from 'src/bed-menu/entities/bed-menu.entity';
 import { Patient } from 'src/patients/entities/patient.entity';
 
 @Entity({ name: 'beds' })
+@Unique(['name', 'room'])
 export class Bed {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ unique: true })
-  name: string; // Ej: "Cama 301A"
+  @Column()
+  name: string;
 
   @Column({ default: 'available' })
   status: 'available' | 'occupied' | 'maintenance';


### PR DESCRIPTION
## Problema
Los nombres de camas tenían restricción de unicidad global, impidiendo usar nombres comunes como "Cama 1" en múltiples habitaciones. Esto es erroneo porque puede pasar que en algunos sanatorios usen los mismos nombres de camas y los diferencien por nombre de habitación.

**Antes:**
- Habitación 20: "Cama 1" ✅ 
- Habitación 21: "Cama 1" ❌ (Error: ya existe)

## Solución
Cambié la restricción de unicidad de global a por habitación.

**Ahora:**
- Habitación 20: "Cama 1" ✅
- Habitación 21: "Cama 1" ✅ (Permitido - diferente habitación)
- Habitación 20: "Cama 1" duplicada ❌ (Error - misma habitación)

## Cambios
- **Entity**: Eliminé `unique: true` de la columna `name`
- **Service**: Agregué validación `validateUniqueBedNameInRoom()`
- **Tipado**: Reemplacé `any` por `FindOptionsWhere<Bed>`